### PR TITLE
Fix CMake 3.4.1 build on Linux

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -79,7 +79,7 @@ link_directories(${gtest_BINARY_DIR}/src)
 # aggressive about warnings.
 cxx_library(gtest "${cxx_strict}" src/gtest-all.cc)
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
-target_link_libraries(gtest_main gtest)
+target_link_libraries(gtest_main PUBLIC gtest)
 
 # Summary of tuple support for Microsoft Visual Studio:
 # Compiler    version(MS)  version(cmake)  Support


### PR DESCRIPTION
Fix error:

  The keyword signature for target_link_libraries has already been used with
  the target "gtest_main".  All uses of target_link_libraries with a target
  must be either all-keyword or all-plain.

It means that form 'target_link_libraries(foo boo)' is deprecated and kept
only for compatibility. If there is at least one modern style form
`target_link_libraries(foo PUBLIC boo)` then user is awared about updates and
should use it everywhere.

This is quite the same as https://github.com/hunter-packages/gtest/commit/cfdab358137fa9d3d281e00338926b26eecceeec
