### PR TITLE
Fix CMake error on Linux …

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -79,7 +79,7 @@ link_directories(${gtest_BINARY_DIR}/src)
 # aggressive about warnings.
 cxx_library(gtest "${cxx_strict}" src/gtest-all.cc)
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
-target_link_libraries(gtest_main PRIVATE gtest)
+target_link_libraries(gtest_main PUBLIC gtest)
 
 # Summary of tuple support for Microsoft Visual Studio:
 # Compiler    version(MS)  version(cmake)  Support

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -79,7 +79,7 @@ link_directories(${gtest_BINARY_DIR}/src)
 # aggressive about warnings.
 cxx_library(gtest "${cxx_strict}" src/gtest-all.cc)
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
-target_link_libraries(gtest_main PUBLIC gtest)
+target_link_libraries(gtest_main PRIVATE gtest)
 
 # Summary of tuple support for Microsoft Visual Studio:
 # Compiler    version(MS)  version(cmake)  Support

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -79,7 +79,7 @@ link_directories(${gtest_BINARY_DIR}/src)
 # aggressive about warnings.
 cxx_library(gtest "${cxx_strict}" src/gtest-all.cc)
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
-target_link_libraries(gtest_main gtest)
+target_link_libraries(gtest_main PUBLIC gtest)
 
 # Summary of tuple support for Microsoft Visual Studio:
 # Compiler    version(MS)  version(cmake)  Support


### PR DESCRIPTION
…caused by missing PUBLIC keyword in target_link_libraries() call.
