### PR TITLE
fix: disable pthreads on GTest project top-level when using MinGW

### DIFF
--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -20,7 +20,16 @@ option(gtest_build_tests "Build all of gtest's own tests." OFF)
 
 option(gtest_build_samples "Build gtest's sample programs." OFF)
 
-option(gtest_disable_pthreads "Disable uses of pthreads in gtest." OFF)
+if (MINGW)
+    # On MinGW, we can have both GTEST_OS_WINDOWS and GTEST_HAS_PTHREAD
+    # defined, but we don't want to use MinGW's pthreads implementation, which
+    # has conformance problems with some versions of the POSIX standard.
+
+    option(gtest_disable_pthreads "Disable uses of pthreads in gtest." ON)
+else()
+    option(gtest_disable_pthreads "Disable uses of pthreads in gtest." OFF)
+endif (MINGW)
+
 
 option(
   gtest_hide_internal_symbols

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -1553,10 +1553,7 @@ class GTEST_API_ Notification {
 };
 # endif  // GTEST_HAS_NOTIFICATION_
 
-// On MinGW, we can have both GTEST_OS_WINDOWS and GTEST_HAS_PTHREAD
-// defined, but we don't want to use MinGW's pthreads implementation, which
-// has conformance problems with some versions of the POSIX standard.
-# if GTEST_HAS_PTHREAD && !GTEST_OS_WINDOWS_MINGW
+# if GTEST_HAS_PTHREAD
 
 // As a C-function, ThreadFuncWithCLinkage cannot be templated itself.
 // Consequently, it cannot select a correct instantiation of ThreadWithParam
@@ -1634,8 +1631,7 @@ class ThreadWithParam : public ThreadWithParamBase {
 
   GTEST_DISALLOW_COPY_AND_ASSIGN_(ThreadWithParam);
 };
-# endif  // !GTEST_OS_WINDOWS && GTEST_HAS_PTHREAD ||
-         // GTEST_HAS_MUTEX_AND_THREAD_LOCAL_
+# endif  // GTEST_HAS_PTHREAD
 
 # if GTEST_HAS_MUTEX_AND_THREAD_LOCAL_
 // Mutex and ThreadLocal have already been imported into the namespace.


### PR DESCRIPTION
in commit a6340420b9cee27f77c5b91bea807121914a5831 "Implement threading
support for gtest on Windows", testing of internal threading in google
test does not work on MinGW. The commit itself contains a comment
indicating that pthreads is not to be used under MinGW due to

> // On MinGW, we can have both GTEST_OS_WINDOWS and GTEST_HAS_PTHREAD
> // defined, but we don't want to use MinGW's pthreads implementation which
> // has conformance problems with some versions of the POSIX standard.

The first comment on #363 might indicate the reason for this breakage.

This commit assures that pthreads is disabled on a top-level by cmake
