### PR TITLE
Reduced the required CMake version back to 3.0.0. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.0)
 
 
 project( googletest-distribution )

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -258,7 +258,7 @@ endfunction()
 # makes sure that the .pdb files for the target end up
 # besides the .lib when the target is installed
 macro( install_pdb_files target )
-  if(MSVC)
+  if(MSVC AND NOT ${CMAKE_VERSION} VERSION_LESS 3.1.0)    # COMPILE_PDB_... properties where introduced with cmake 3.1
     set(debugOutputDir ${PROJECT_BINARY_DIR}/Debug)
     # make sure the compiler generated .pdb files are palced besides the .lib files
     if(NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
The .pdb file fix will only work for CMake versions 3.1 or higher.
