### PR TITLE
Issue17

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ the repository [https://github.com/hunter-packages/gtest](https://github.com/hun
 
 ## Modifications ##
 
-This fork adds an install target that generates the `.cmake` files that are required for a [config file](https://cmake.org/cmake/help/v3.10/manual/cmake-packages.7.html#id1) based CMake package.
+* Add an install target that also generates `<target>Config.cmake` files which allows installing the project
+as a relocatable config file based CMake package. [https://cmake.org/cmake/help/v3.10/manual/cmake-packages.7.html#id1](https://cmake.org/cmake/help/v3.10/manual/cmake-packages.7.html#id1) 
+
+* Add interface compile definitions for the dll export macros when building as shared library with **MSVC**.
+This reliefes the consumers from manually setting the `GTEST_LINKED_AS_SHARED_LIBRARY=1` compile definition for their
+targets.
 
 ## Usage Example ##
 

--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -85,12 +85,14 @@ cxx_library(gmock
             "${cxx_strict}"
             "${gtest_dir}/src/gtest-all.cc"
             src/gmock-all.cc)
+add_export_macro_interface_defintion(gmock GTEST_LINKED_AS_SHARED_LIBRARY=1 )
 
 cxx_library(gmock_main
             "${cxx_strict}"
             "${gtest_dir}/src/gtest-all.cc"
             src/gmock-all.cc
             src/gmock_main.cc)
+add_export_macro_interface_defintion( gmock_main GTEST_LINKED_AS_SHARED_LIBRARY=1 )
 
 ########################################################################
 #

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -78,10 +78,10 @@ link_directories(${gtest_BINARY_DIR}/src)
 # are used for other targets, to ensure that gtest can be compiled by a user
 # aggressive about warnings.
 cxx_library(gtest "${cxx_strict}" src/gtest-all.cc)
-add_export_macro_interface_defintion(gmock GTEST_LINKED_AS_SHARED_LIBRARY=1 )
+add_export_macro_interface_defintion(gtest GTEST_LINKED_AS_SHARED_LIBRARY=1 )
 
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
-add_export_macro_interface_defintion(gmock GTEST_MAIN_LINKED_AS_SHARED_LIBRARY=1 )
+add_export_macro_interface_defintion(gtest_main GTEST_MAIN_LINKED_AS_SHARED_LIBRARY=1 )
 target_link_libraries(gtest_main PUBLIC gtest)
 
 # Summary of tuple support for Microsoft Visual Studio:

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -78,7 +78,10 @@ link_directories(${gtest_BINARY_DIR}/src)
 # are used for other targets, to ensure that gtest can be compiled by a user
 # aggressive about warnings.
 cxx_library(gtest "${cxx_strict}" src/gtest-all.cc)
+add_export_macro_interface_defintion(gmock GTEST_LINKED_AS_SHARED_LIBRARY=1 )
+
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
+add_export_macro_interface_defintion(gmock GTEST_MAIN_LINKED_AS_SHARED_LIBRARY=1 )
 target_link_libraries(gtest_main PUBLIC gtest)
 
 # Summary of tuple support for Microsoft Visual Studio:

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -259,6 +259,16 @@ function(py_test name)
   endif()
 endfunction()
 
+# Adds the given macro definition to the interface of the target when compiling as shared library and msvc.
+function( add_export_macro_interface_defintion target definition )
+  if(MSVC)
+    get_property(type TARGET ${target} PROPERTY TYPE)
+    if( ${type} STREQUAL SHARED_LIBRARY )
+      target_compile_definitions( ${target} INTERFACE ${definition})
+    endif()
+  endif()
+endfunction()
+
 # install_pdb_files( target )
 #
 # makes sure that the .pdb files for the target end up

--- a/googletest/include/gtest/internal/gtest-port.h
+++ b/googletest/include/gtest/internal/gtest-port.h
@@ -969,6 +969,25 @@ using ::std::tuple_size;
 # define GTEST_API_
 #endif // GTEST_API_
 
+// Add an API macro for gtest_main
+#ifndef GTEST_MAIN_API_
+
+#ifdef _MSC_VER
+# if GTEST_MAIN_LINKED_AS_SHARED_LIBRARY
+#  define GTEST_MAIN_API_ __declspec(dllimport)
+# elif GTEST_CREATE_SHARED_LIBRARY
+#  define GTEST_MAIN_API_ __declspec(dllexport)
+# endif
+#elif __GNUC__ >= 4 || defined(__clang__)
+# define GTEST_MAIN_API_ __attribute__((visibility ("default")))
+#endif // _MSC_VER
+
+#endif // GTEST_API_
+
+#ifndef GTEST_MAIN_API_
+# define GTEST_MAIN_API_
+#endif // GTEST_MAIN_API_
+
 #ifdef __GNUC__
 // Ask the compiler to never inline a given function.
 # define GTEST_NO_INLINE_ __attribute__((noinline))

--- a/googletest/src/gtest_main.cc
+++ b/googletest/src/gtest_main.cc
@@ -31,7 +31,7 @@
 
 #include "gtest/gtest.h"
 
-GTEST_API_ int main(int argc, char **argv) {
+GTEST_MAIN_API_ int main(int argc, char **argv) {
   printf("Running main() from gtest_main.cc\n");
   testing::InitGoogleTest(&argc, argv);
   const int result = RUN_ALL_TESTS();


### PR DESCRIPTION
Fixes #17

The changes in this patch fix a linker error that consumers get when compiling with `MSVC` and `BUILD_SHARED_LIBS=ON`. Previous to this patch, the consumer had to manually set the `GTEST_LINKED_AS_SHARED_LIBRARY=1` for his targets that link to the shared gtest libraries. 
With this patch, the definitions for the clients are set automatically.
