### PR TITLE
Issue20

### DIFF
--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -92,76 +92,13 @@ cxx_library(gmock_main
             src/gmock-all.cc
             src/gmock_main.cc)
 
+# preserve compatibility with old GTest hunter package
+set_target_properties(gmock_main PROPERTIES EXPORT_NAME main)
+
 ########################################################################
 #
 # Install rules
-
-set(config_install_dir "lib/cmake/GMock")
-set(include_install_dir "include")
-
-set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
-
-
-# Configuration
-set(version_config "${generated_dir}/GMockConfigVersion.cmake")
-set(project_config "${generated_dir}/GMockConfig.cmake")
-set(targets_export_name "GMockTargets")
-set(namespace "GMock::")
-
-# Include module with fuction 'write_basic_package_version_file'
-include(CMakePackageConfigHelpers)
-
-# Configure '<PROJECT-NAME>ConfigVersion.cmake'
-# Note: PROJECT_VERSION is used as a VERSION
-write_basic_package_version_file(
-  "${version_config}" COMPATIBILITY SameMajorVersion
-)
-
-# Configure '<PROJECT-NAME>Config.cmake'
-# Use variables:
-#   * targets_export_name
-#   * PROJECT_NAME
-configure_package_config_file(
-  "cmake/Config.cmake.in"
-  "${project_config}"
-  INSTALL_DESTINATION "${config_install_dir}"
-)
-
-
-set_target_properties(gmock_main PROPERTIES EXPORT_NAME main)
-# Targets:
-install(
-  TARGETS gmock gmock_main
-  EXPORT "${targets_export_name}"
-  LIBRARY DESTINATION "lib"
-  ARCHIVE DESTINATION "lib"
-  RUNTIME DESTINATION "bin"
-  INCLUDES DESTINATION "${include_install_dir}"
-)
-
-# Headers:
-install(
-  DIRECTORY ${gmock_SOURCE_DIR}/include/gmock
-  DESTINATION "${include_install_dir}"
-  FILES_MATCHING PATTERN "*.h"
-)
-
-# Config
-install(
-  FILES "${project_config}" "${version_config}"
-  DESTINATION "${config_install_dir}"
-)
-
-# Config
-install(
-  EXPORT "${targets_export_name}"
-  NAMESPACE "${namespace}"
-  DESTINATION "${config_install_dir}"
-)
-
-# Debug information .pdb for MSVC
-install_pdb_files(gmock)
-install_pdb_files(gmock_main)
+add_install_rules( GMock gmock;gmock_main )
 
 ########################################################################
 #

--- a/googlemock/CMakeLists.txt
+++ b/googlemock/CMakeLists.txt
@@ -100,7 +100,7 @@ set_target_properties(gmock_main PROPERTIES EXPORT_NAME main)
 ########################################################################
 #
 # Install rules
-add_install_rules( GMock gmock;gmock_main )
+add_install_rules( GMock "gmock;gmock_main" )
 
 ########################################################################
 #

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -80,6 +80,8 @@ link_directories(${gtest_BINARY_DIR}/src)
 cxx_library(gtest "${cxx_strict}" src/gtest-all.cc)
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
 target_link_libraries(gtest_main PUBLIC gtest)
+# preserve compatibility with old GTest hunter package
+set_target_properties(gtest_main PROPERTIES EXPORT_NAME main)
 
 # Summary of tuple support for Microsoft Visual Studio:
 # Compiler    version(MS)  version(cmake)  Support
@@ -94,72 +96,7 @@ endif()
 ########################################################################
 #
 # Install rules
-
-set(config_install_dir "lib/cmake/GTest")
-set(include_install_dir "include")
-
-set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
-
-# Configuration
-set(version_config "${generated_dir}/GTestConfigVersion.cmake")
-set(project_config "${generated_dir}/GTestConfig.cmake")
-set(targets_export_name "GTestTargets")
-set(namespace "GTest::")
-
-# Include module with fuction 'write_basic_package_version_file'
-include(CMakePackageConfigHelpers)
-
-# Configure '<PROJECT-NAME>ConfigVersion.cmake'
-# Note: PROJECT_VERSION is used as a VERSION
-write_basic_package_version_file(
-  "${version_config}" COMPATIBILITY SameMajorVersion
-)
-
-# Configure '<PROJECT-NAME>Config.cmake'
-# Use variables:
-#   * targets_export_name
-#   * PROJECT_NAME
-configure_package_config_file(
-  "cmake/Config.cmake.in"
-  "${project_config}"
-  INSTALL_DESTINATION "${config_install_dir}"
-)
-
-set_target_properties(gtest_main PROPERTIES EXPORT_NAME main)
-
-# Targets:
-install(
-  TARGETS gtest gtest_main
-  EXPORT "${targets_export_name}"
-  LIBRARY DESTINATION "lib"
-  ARCHIVE DESTINATION "lib"
-  RUNTIME DESTINATION "bin"
-  INCLUDES DESTINATION "${include_install_dir}"
-)
-
-# Headers:
-install(
-  DIRECTORY ${gtest_SOURCE_DIR}/include/gtest
-  DESTINATION "${include_install_dir}"
-  FILES_MATCHING PATTERN "*.h"
-)
-
-# Config
-install(
-  FILES "${project_config}" "${version_config}"
-  DESTINATION "${config_install_dir}"
-)
-
-# Config
-install(
-  EXPORT "${targets_export_name}"
-  NAMESPACE "${namespace}"
-  DESTINATION "${config_install_dir}"
-)
-
-# Debug information .pdb for MSVC
-install_pdb_files(gtest)
-install_pdb_files(gtest_main)
+add_install_rules( GTest gtest;gtest_main)
 
 ########################################################################
 #

--- a/googletest/CMakeLists.txt
+++ b/googletest/CMakeLists.txt
@@ -99,7 +99,7 @@ endif()
 ########################################################################
 #
 # Install rules
-add_install_rules( GTest gtest;gtest_main)
+add_install_rules( GTest "gtest;gtest_main")
 
 ########################################################################
 #

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -374,7 +374,7 @@ function( install_pdb_files target )
       target_has_pdb_linker_output( has_pdb_linker_output ${target} ${config})
       if(has_pdb_linker_output)
 
-        set( output_name ${target}${name_config_postfix}-compiler )
+        set( output_name ${target}${name_config_postfix}-linker )
         set_property( TARGET ${target} PROPERTY PDB_NAME_${config_suffix} ${output_name} )
         set_property( TARGET ${target} PROPERTY PDB_OUTPUT_DIRECTORY_${config_suffix} ${output_dir} )
 

--- a/googletest/cmake/internal_utils.cmake
+++ b/googletest/cmake/internal_utils.cmake
@@ -274,8 +274,7 @@ endfunction()
 # Adds install rules for the GMock and GTest packages.
 function( add_install_rules package targets )
 
-  set(config_install_dir "lib/cmake/${package}")
-  set(include_install_dir "include")
+  set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${package}")
 
   set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
@@ -308,17 +307,17 @@ function( add_install_rules package targets )
   install(
     TARGETS ${targets}
     EXPORT "${targets_export_name}"
-    LIBRARY DESTINATION "lib"
-    ARCHIVE DESTINATION "lib"
-    RUNTIME DESTINATION "bin"
-    INCLUDES DESTINATION "${include_install_dir}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
 
   # Headers:
   string(TOLOWER ${package} package_lower)
   install(
     DIRECTORY ${${package_lower}_SOURCE_DIR}/include/${package_lower}
-    DESTINATION "${include_install_dir}"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     FILES_MATCHING PATTERN "*.h"
   )
 
@@ -365,7 +364,7 @@ function( install_pdb_files target )
 
         install( 
           FILES ${output_dir}/${output_name}.pdb
-          DESTINATION "lib"
+          DESTINATION "${CMAKE_INSTALL_LIBDIR}"
           CONFIGURATIONS ${config}
         )
 
@@ -381,7 +380,7 @@ function( install_pdb_files target )
 
         install( 
           FILES ${output_dir}/${output_name}.pdb
-          DESTINATION "bin"
+          DESTINATION "${CMAKE_INSTALL_BINDIR}"
           CONFIGURATIONS ${config}
         )
 


### PR DESCRIPTION
Patch for fixing #20 

* Factors install rule cmake code into the new function `add_install_rules()`.
* Replaces hard coded occurences of `lib`, ìnclude` and `bin` install destinations with the values of the variabels `CMAKE_INSTALL_LIBDIR`, `CMAKE_INSTALL_INCLUDEDIR` and `CMAKE_INSTALL_BINDIR`
